### PR TITLE
Merge "SERVER_DEV95 into Master"

### DIFF
--- a/HSLD/Assets/Scenes/Core/CoreUIManager.cs
+++ b/HSLD/Assets/Scenes/Core/CoreUIManager.cs
@@ -157,15 +157,29 @@ public class CoreUIManager : MonoBehaviour
         }
     }
 
-    public void OnOffResultMakeFriendUI(bool InBValue)
+    public void OnOffResultMakeFriendUI(bool InBValue, bool isMakeFriendTrue)
     {
         if (InBValue == true)
         {
             ResultMakeFriendUI.SetActive(true);
+
+            if(isMakeFriendTrue)
+            {
+                ResultMakeFriendUI.transform.Find("Text_text").GetComponent<Text>().text = "상대방이 친구 추가를 받았습니다.";
+            }
+            else
+            {
+                ResultMakeFriendUI.transform.Find("Text_text").GetComponent<Text>().text = "상대방이 친구 추가를 거절했습니다.";
+            }
         }
         else if (InBValue == false)
         {
             ResultMakeFriendUI.SetActive(false);
         }
+    }
+
+    public void UI_OffResultMakeFriendUI()
+    {
+        ResultMakeFriendUI.SetActive(false);
     }
 }

--- a/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_Others.cs
+++ b/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_Others.cs
@@ -78,6 +78,8 @@ public partial class NetworkManager : MonoBehaviour {
             int index1 = www.downloadHandler.text.IndexOf("Server IP : ") + 12;
             int index2 = www.downloadHandler.text.IndexOf(".HSLD", index1);
 
+            Debug.Log("index1 : " + index1 + " index2 : " + index2 + " 입니다.");
+
             iP_ADDRESS = www.downloadHandler.text.Substring(index1, index2 - index1);
 
             // Or retrieve results as binary data

--- a/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_Recv.cs
+++ b/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_Recv.cs
@@ -297,8 +297,9 @@ public partial class NetworkManager : MonoBehaviour
         else if (recvType == (int)PROTOCOL.NOTIFY_MAKE_FRIEND_INFO)
         {
             int iBuffer = BitConverter.ToInt32(NewDataRecvBuffer, 4);
-            string nickNameBuffer = Encoding.Default.GetString(NewDataRecvBuffer, 8, iBuffer);
+            string nickNameBuffer = Encoding.Unicode.GetString(NewDataRecvBuffer, 8, iBuffer);
 
+            Debug.Log("받은 닉네임은 : " + nickNameBuffer);
             GameObject.Find("GameCores").transform.Find("CoreUIManager").GetComponent<CoreUIManager>().OnUI_DEMAND_FRIEND_UDP(nickNameBuffer);
         }
         else if (recvType == (int)PROTOCOL.CHECK_ANSWER_MAKE_FRIEND)

--- a/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_Recv.cs
+++ b/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_Recv.cs
@@ -299,7 +299,7 @@ public partial class NetworkManager : MonoBehaviour
             int iBuffer = BitConverter.ToInt32(NewDataRecvBuffer, 4);
             string nickNameBuffer = Encoding.Unicode.GetString(NewDataRecvBuffer, 8, iBuffer);
 
-            Debug.Log("받은 닉네임은 : " + nickNameBuffer);
+            //Debug.Log("받은 닉네임은 : " + nickNameBuffer);
             GameObject.Find("GameCores").transform.Find("CoreUIManager").GetComponent<CoreUIManager>().OnUI_DEMAND_FRIEND_UDP(nickNameBuffer);
         }
         else if (recvType == (int)PROTOCOL.CHECK_ANSWER_MAKE_FRIEND)

--- a/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_UDP.cs
+++ b/HSLD/Assets/Scenes/Core/NetworkManager/NetworkManager_UDP.cs
@@ -38,14 +38,18 @@ public partial class NetworkManager : MonoBehaviour
 
     enum UDP_PROTOCOL : int
     {
-            INVITE_FRIEND = 1
+          INVITE_FRIEND = 1
         , DEMAND_FRIEND = 2
 
-        , RESULT_FRIEND = 7
+        , RESULT_TRUE_FRIEND = 6
+        , RESULT_FAIL_FRIEND = 7
+
         , ANNOUNCEMENT = 8  // 해당 사항은, 전체 유저에게 전송해야하므로, 큐형식이 아닌, 다르게 구현.
 
         , SEND_PORT = 9
         , CONFIRM_PORT = 10
+
+        , DUMMY_FOR_STUN = 11
     };
 
     public static void ProcessRecvUDPData(int InBuffer)
@@ -66,10 +70,15 @@ public partial class NetworkManager : MonoBehaviour
         {
             GameObject.Find("GameCores").transform.Find("CoreUIManager").GetComponent<CoreUIManager>();
         }
-        else if (InBuffer == (int)UDP_PROTOCOL.RESULT_FRIEND)
+        else if (InBuffer == (int)UDP_PROTOCOL.RESULT_FAIL_FRIEND)
         {
-            Debug.Log("UDP Message : 친구 추가 요청에 대한 답변을 받았습니다. ");
-            GameObject.Find("GameCores").transform.Find("CoreUIManager").GetComponent<CoreUIManager>().OnOffResultMakeFriendUI(true);
+            Debug.Log("UDP Message : 친구 추가 요청에 대한 나쁜 답변을 받았습니다. ");
+            GameObject.Find("GameCores").transform.Find("CoreUIManager").GetComponent<CoreUIManager>().OnOffResultMakeFriendUI(true, false);
+        }
+        else if (InBuffer == (int)UDP_PROTOCOL.RESULT_TRUE_FRIEND)
+        {
+            Debug.Log("UDP Message : 친구 추가 요청에 대한 좋은 답변을 받았습니다. ");
+            GameObject.Find("GameCores").transform.Find("CoreUIManager").GetComponent<CoreUIManager>().OnOffResultMakeFriendUI(true, true);
         }
         else if (InBuffer == (int)UDP_PROTOCOL.ANNOUNCEMENT)
         {

--- a/HSLD/Assets/Scenes/_1_TitleScene/TitleScene.unity
+++ b/HSLD/Assets/Scenes/_1_TitleScene/TitleScene.unity
@@ -2509,7 +2509,7 @@ GameObject:
   - component: {fileID: 292489198}
   - component: {fileID: 292489197}
   m_Layer: 8
-  m_Name: NameUiText (1)
+  m_Name: Text_text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2530,8 +2530,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 4, y: 25}
-  m_SizeDelta: {x: 585.2, y: 167.1}
+  m_AnchoredPosition: {x: 6.8, y: 4.1}
+  m_SizeDelta: {x: 833.1, y: 212.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &292489197
 MonoBehaviour:
@@ -2565,7 +2565,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\uCE5C\uCD94 \uBCF4\uB0B8\uAC70 \uBC1B\uC74C."
+  m_Text: "\uC0C1\uB300\uBC29\uC774 \uCE5C\uAD6C \uCD94\uAC00\uB97C \uBC1B\uC558\uC2B5\uB2C8\uB2E4."
 --- !u!222 &292489198
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -11199,7 +11199,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\uC774\uC81C\uBD80\uD130 \uB108\uB294 \uC544\uC2F8\uAC00 \uC544\uB2C8\uB2E4."
+  m_Text: "[\uCE5C\uAD6CUI]"
 --- !u!222 &1157694775
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -15650,8 +15650,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1183125662}
-        m_MethodName: OnOffResultMakeFriendUI
-        m_Mode: 6
+        m_MethodName: UI_OffResultMakeFriendUI
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/HSLD/Assets/Scenes/_2_LoginScene/LoginScene.unity
+++ b/HSLD/Assets/Scenes/_2_LoginScene/LoginScene.unity
@@ -279,7 +279,7 @@ RectTransform:
   - {fileID: 370125806}
   - {fileID: 870158494}
   m_Father: {fileID: 1746628120}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -986,7 +986,7 @@ RectTransform:
   - {fileID: 1558377687}
   - {fileID: 434880865}
   m_Father: {fileID: 1746628120}
-  m_RootOrder: 3
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1240,7 +1240,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 0.16037999}
   m_Children: []
   m_Father: {fileID: 1746628120}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1317,7 +1317,7 @@ RectTransform:
   m_Children:
   - {fileID: 1339151221}
   m_Father: {fileID: 1746628120}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2060,7 +2060,7 @@ RectTransform:
   - {fileID: 368631393}
   - {fileID: 1418266888}
   m_Father: {fileID: 1746628120}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2649,13 +2649,13 @@ RectTransform:
   - {fileID: 309618119}
   - {fileID: 1070143430}
   - {fileID: 1219308756}
-  - {fileID: 742063467}
   - {fileID: 259107897}
   - {fileID: 1425270233}
   - {fileID: 1032583593}
   - {fileID: 2069792440}
   - {fileID: 1829313604}
   - {fileID: 1008049749}
+  - {fileID: 742063467}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2692,7 +2692,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 0.16037507}
   m_Children: []
   m_Father: {fileID: 1746628120}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3044,7 +3044,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 0.16037507}
   m_Children: []
   m_Father: {fileID: 1746628120}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/HSLD/Assets/Scenes/_2_LoginScene/LoginSceneManager.cs
+++ b/HSLD/Assets/Scenes/_2_LoginScene/LoginSceneManager.cs
@@ -90,7 +90,7 @@ public class LoginSceneManager : MonoBehaviour {
     public void UI_OnOff_NewNicknameUI(bool InIsActive = true)
     {
         //GameObject.Find("SignUp_UI").transform.Find("OnOff_All").gameObject.SetActive(true);
-        GameObject.Find("OnOff_UI").transform.Find("SignUp_UI").gameObject.SetActive(InIsActive);
+        GameObject.Find("Canvas_2D").transform.Find("SignUp_UI").gameObject.SetActive(InIsActive);
 
         //GameObject.Find("OnOff_UI").gameObject.SetActive(true);
     }

--- a/HSLD/Assets/Scenes/_3_MainUIScene/MainUIScene.unity
+++ b/HSLD/Assets/Scenes/_3_MainUIScene/MainUIScene.unity
@@ -4043,7 +4043,7 @@ MonoBehaviour:
   m_LineType: 0
   m_HideMobileInput: 0
   m_CharacterValidation: 0
-  m_CharacterLimit: 0
+  m_CharacterLimit: 20
   m_OnEndEdit:
     m_PersistentCalls:
       m_Calls: []

--- a/HSLD/ProjectSettings/EditorBuildSettings.asset
+++ b/HSLD/ProjectSettings/EditorBuildSettings.asset
@@ -26,10 +26,10 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/_6_InGameScene/InGameScene.unity
     guid: 114fbbeb5fed8bc44ae861983dd621d6
-  - enabled: 1
-    path: Assets/Scenes/_7_CasualGameScene/CasualGameScene.unity
-    guid: d573ebdcfbbd4db489b26f1922a8787c
-  - enabled: 1
-    path: Assets/Scenes/_8_TutorialScene/TutorialScene.unity
-    guid: cfc1f123950a7754fbe98159d96b6109
+  - enabled: 0
+    path: 
+    guid: 00000000000000000000000000000000
+  - enabled: 0
+    path: 
+    guid: 00000000000000000000000000000000
   m_configObjects: {}

--- a/Server/Server/IOCPServer/UDPManager.h
+++ b/Server/Server/IOCPServer/UDPManager.h
@@ -11,7 +11,9 @@ enum UDP_PROTOCOL : int
 		INVITE_FRIEND = 1
 	,	DEMAND_FRIEND = 2
 
-	,	RESULT_FRIEND =	7
+	,	RESULT_TRUE_FRIEND = 6
+	,   RESULT_FAIL_FRIEND = 7
+
 	,	ANNOUNCEMENT = 8	// 해당 사항은, 전체 유저에게 전송해야하므로, 큐형식이 아닌, 다르게 구현.
 
 	,	SEND_PORT = 9
@@ -20,12 +22,15 @@ enum UDP_PROTOCOL : int
 	,	DUMMY_FOR_STUN = 11
 };
 
+// UDP Manager 구조의 변경이 필요함...
 class UDPManager
 {
 	const char				CONST_INVITE_FRIEND;
 	const char				CONST_DEMAND_FRIEND;
 
-	const char				CONST_RESULT_FRIEND;
+	const char				CONST_RESULT_TRUE_FRIEND;
+	const char				CONST_RESULT_FAIL_FRIEND;
+
 	const char				CONST_ANNOUNCEMENT;
 	const char				CONST_CONFIRM_PORT;
 
@@ -37,7 +42,8 @@ class UDPManager
 	CUSTOM_QUEUE::CustomQueue<weak_ptr<UserData>> friendInviteMessageQueue;	// INVITE_FRIEND = 1
 	CUSTOM_QUEUE::CustomQueue<weak_ptr<UserData>> friendDemandMessageQueue; // DEMAND_FRIEND = 2
 
-	CUSTOM_QUEUE::CustomQueue<weak_ptr<UserData>> friendResultMessageQueue;	// RESULT_FRIEND = 7
+	CUSTOM_QUEUE::CustomQueue<weak_ptr<UserData>> friendTrueResultMessageQueue;	// RESULT_FRIEND = 6
+	CUSTOM_QUEUE::CustomQueue<weak_ptr<UserData>> friendFailResultMessageQueue;	// RESULT_FRIEND = 6
 
 	CUSTOM_QUEUE::CustomQueue<weak_ptr<UserData>> confirmPortMessageQueue; // CONFIRM_PORT = 10
 	//std::vector<CUSTOM_QUEUE::CustomQueue<weak_ptr<UserData>>> messageQueue;
@@ -61,8 +67,11 @@ public:
 		case UDP_PROTOCOL::DEMAND_FRIEND:
 			friendDemandMessageQueue.Push(pInUserData);
 			break;
-		case UDP_PROTOCOL::RESULT_FRIEND:	
-			friendResultMessageQueue.Push(pInUserData);
+		case UDP_PROTOCOL::RESULT_TRUE_FRIEND:
+			friendTrueResultMessageQueue.Push(pInUserData);
+			break;
+		case UDP_PROTOCOL::RESULT_FAIL_FRIEND:
+			friendFailResultMessageQueue.Push(pInUserData);
 			break;
 		case UDP_PROTOCOL::CONFIRM_PORT:
 			confirmPortMessageQueue.Push(pInUserData);
@@ -77,15 +86,20 @@ public:
 		{
 			if (!friendInviteMessageQueue.IsEmpty())
 			{
-				_SendInviteMessage();
+				_SendFriendInviteMessage();
 			}
 			else if (!friendDemandMessageQueue.IsEmpty())
 			{
-				_SendDemandMessage();
+				_SendFriendDemandMessage();
 			}
-			else if (!friendResultMessageQueue.IsEmpty())
+			
+			else if (!friendTrueResultMessageQueue.IsEmpty())
 			{
-				_SendResultMessage();
+				_SendFriendTrueResultMessage();
+			}
+			else if (!friendFailResultMessageQueue.IsEmpty())
+			{
+				_SendFriendFailResultMessage();
 			}
 			else if (!confirmPortMessageQueue.IsEmpty())
 			{
@@ -103,9 +117,10 @@ public:
 
 public:
 	//void _SendMessage(const char InChar);
-	void _SendInviteMessage();
-	void _SendDemandMessage();
-	void _SendResultMessage();
+	void _SendFriendInviteMessage();
+	void _SendFriendDemandMessage();
+	void _SendFriendTrueResultMessage();
+	void _SendFriendFailResultMessage();
 	void _SendConfirmMessage();
 
 public:

--- a/Server/Server/SceneNetworkManager/_2_MainUIScene/MainUIScene.cpp
+++ b/Server/Server/SceneNetworkManager/_2_MainUIScene/MainUIScene.cpp
@@ -50,8 +50,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::ProcessData(const int InRecvType, Socke
 */
 void SCENE_NETWORK_MANAGER::MainUiScene::_DemandFriendInfoProcess(SocketInfo* pClient)
 {
-	std::cout << "[DEMAND_FRIEND] DEBUG - 1 \n";
-
 	int friendNum = pClient->pUserNode->GetFriendNicknameContSize();
 
 	//if (pClient->pUserNode->GetTemporaryFriendUserData().expired() == false)
@@ -59,12 +57,8 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandFriendInfoProcess(SocketInfo* pC
 	//	friendNum -= 1;
 	//}
 
-	std::cout << "[DEMAND_FRIEND] DEBUG - 2 \n";
-
 	memcpy(pClient->buf, reinterpret_cast<const char*>(&PERMIT_FRIEND_INFO), sizeof(int));
 	memcpy(pClient->buf + 4, reinterpret_cast<char*>(&friendNum), sizeof(int));
-
-	std::cout << "[DEMAND_FRIEND] DEBUG - 3 \n";
 
 	pClient->dataSize = 8;
 
@@ -77,8 +71,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandFriendInfoProcess(SocketInfo* pC
 
 	if (friendNum > 0)
 	{
-		std::cout << "[DEMAND_FRIEND] DEBUG - 4 \n";
-
 		int stringSize{};
 		Type_Nickname stringBuffer{};
 		bool isOnLogin{};
@@ -88,17 +80,11 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandFriendInfoProcess(SocketInfo* pC
 
 		for (int i = 0; i < friendNum; ++i)
 		{
-			std::cout << "[DEMAND_FRIEND] DEBUG - 5 \n";
-
 			// 해당 컨테이너의 i번째 닉네임.
 			stringBuffer = pClient->pUserNode->GetFriendNicknameWithIndex(i);
 
-			std::cout << "[DEMAND_FRIEND] DEBUG - 6 \n";
-
 			// 해당 아이디로 현재 상태 판정, True일경우 1, false일 경우 0
 			pBuffer = pUserData->SearchUserNodeByNicknameWithActiveCharacterIndex(stringBuffer, isOnLogin, isOnMatch, characterIndex);
-
-			std::cout << "[DEMAND_FRIEND] DEBUG - 7 \n";
 
 			// 0일 경우, 없는 닉네임. 
 			// 1일 경우, 닉네임은 있는데 비로그인.
@@ -108,8 +94,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandFriendInfoProcess(SocketInfo* pC
 			//std::cout << "pClient->dataSize : " << pClient->dataSize << std::endl;
 
 			pClient->dataSize += 5;	// 4 Bool Type + 4 characterIndex;
-
-			std::cout << "[DEMAND_FRIEND] DEBUG - 8 \n";
 
 			// 0인 경우, (현재 로직상 이 조건이 트루일 수 없음)
 			if (!isOnMatch)
@@ -121,8 +105,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandFriendInfoProcess(SocketInfo* pC
 				continue;
 			}
 
-			std::cout << "[DEMAND_FRIEND] DEBUG - 9 \n";
-
 			if (!isOnLogin)	// 로그인 안했을 때,
 				memcpy(pClient->buf + pClient->dataSize - 5, reinterpret_cast<const char*>(&CONST_TRUE), sizeof(int));
 			else if (pBuffer->GetSocketInfo()->pRoomIter == nullptr)	// 접속 후, 로비
@@ -130,31 +112,19 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandFriendInfoProcess(SocketInfo* pC
 			else	// 접속 후, 게임중.
 				memcpy(pClient->buf + pClient->dataSize - 5, reinterpret_cast<const char*>(&CONST_3), sizeof(int));
 
-			std::cout << "[DEMAND_FRIEND] DEBUG - 10 \n";
-
 			pClient->buf[pClient->dataSize - 1] = characterIndex;
-
-			std::cout << "[DEMAND_FRIEND] DEBUG - 11 \n";
 
 			pClient->pUserNode->SetFreindUserDataWithIndex(pBuffer, i); // weak_ptr로 변환.
 
-			std::cout << "[DEMAND_FRIEND] DEBUG - 12 \n";
-
 			stringSize = MultiByteToWideChar(CP_ACP, 0, &stringBuffer[0], stringBuffer.size(), NULL, NULL);
-
-			std::cout << "[DEMAND_FRIEND] DEBUG - 13 \n";
 
 			wstring uniStrBuffer(stringSize, 0);
 			MultiByteToWideChar(CP_ACP, 0, &stringBuffer[0], stringBuffer.size(), &uniStrBuffer[0], stringSize);
 			
-			std::cout << "[DEMAND_FRIEND] DEBUG - 14 \n";
-
 			stringSize = uniStrBuffer.size() * 2;
 
 			memcpy(pClient->buf + pClient->dataSize , reinterpret_cast<char*>(&stringSize), sizeof(int));
 			memcpy(pClient->buf + pClient->dataSize + 4, uniStrBuffer.data(), stringSize);
-
-			std::cout << "[DEMAND_FRIEND] DEBUG - 15 \n";
 
 			pClient->dataSize += (4 + stringSize); 
 		}
@@ -379,8 +349,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DelayFriendInviteProcess(SocketInfo* p
 */
 void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendProcess(SocketInfo* pClient)
 {
-	std::cout << pClient->pUserNode->GetNickname() << "에 의해 DemandMakeFriendProcess가 호출되었습니다. \n";
-
 	int iBuffer = reinterpret_cast<int&>(pClient->buf[4]);	// 버퍼 사이즈
 	//pClient->buf[8 + iBuffer] = '\0';// wchar는 \0도 두개...
 	//pClient->buf[9 + iBuffer] = '\0';// wchar는 \0도 두개...
@@ -389,8 +357,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendProcess(SocketInfo* pC
 	memcpy(&wideStrBuffer[0], pClient->buf + 8, iBuffer);
 
 	Type_Nickname NicknameBuffer = CONVERT_UTIL::WStringToString(wideStrBuffer);
-
-	//std::cout << "요청한 친구초대는 ~ 입니다. : " << NicknameBuffer << " 사이즈는 : " << NicknameBuffer.size()<< std::endl;
 
 	bool isOnLogin{ false };
 	bool isOnMatch{ false };
@@ -412,8 +378,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendProcess(SocketInfo* pC
 	// 상대방이 로그인 하지 않은 상황 : ANSWER_MAKE_FRIEND + 0 + 0 .
 	if (!isOnLogin)
 	{
-		//std::cout << "[FRIEND] DEBUG 3 " << std::endl;
-
 		memcpy(pClient->buf, reinterpret_cast<const char*>(&CHECK_DEMAND_MAKE_FRIEND), sizeof(int));
 		memcpy(pClient->buf + 4, reinterpret_cast<const char*>(&CONST_FALSE), sizeof(int));
 		memcpy(pClient->buf + 8, reinterpret_cast<const char*>(&CONST_FALSE), sizeof(int));
@@ -423,8 +387,7 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendProcess(SocketInfo* pC
 	}
 
 	iBuffer = pBuffer->GetFriendNicknameContSize();
-	//std::cout << "[FRIEND] DEBUG 4 " << std::endl;
-
+	
 	// 상대방이 맥스 프렌드인 상황 : ANSWER_MAKE_FRIEND + 0 + 1 
 	if (iBuffer >= 4)
 	{
@@ -446,7 +409,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendProcess(SocketInfo* pC
 		memcpy(pClient->buf + 8, reinterpret_cast<const char*>(&CONST_2), sizeof(int));
 
 		pClient->dataSize = 12;
-		//std::cout << "상대방이 이미 친구 관련 중인 상황 : ANSWER_MAKE_FRIEND + 0 + 2 \n";
 		return;
 	}
 
@@ -458,11 +420,8 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendProcess(SocketInfo* pC
 		memcpy(pClient->buf + 8, reinterpret_cast<const char*>(&CONST_2), sizeof(int));
 
 		pClient->dataSize = 12;
-		//std::cout << "상대방이 이미 친구 관련 중인 상황 : ANSWER_MAKE_FRIEND + 0 + 2 \n";
 		return;
 	}
-
-	//std::cout << "[FRIEND] DEBUG 5 " << std::endl;
 
 	// 상대방에게 친구 요청을 보내고, 나와 친구에 임시로 모두 저장함. : ANSWER_MAKE_FRIEND + 1
 	//pBuffer->SetDemandFriendContIndex(pBuffer->SetInsertFriendNickname(pClient->pUserNode->GetNickname()));
@@ -478,23 +437,19 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendProcess(SocketInfo* pC
 
 	//std::cout << "상대방에게 친구 요청을 보냄 : ANSWER_MAKE_FRIEND + 1 \n";
 	pClient->dataSize = 8;
-
-	std::cout << pClient->pUserNode->GetNickname() << "에 의해 DemandMakeFriendProcess가 리턴되었습니다. \n";
 }
 
 void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendInfoProcess(SocketInfo* pClient)
 {
-	std::cout << pClient->pUserNode->GetNickname() << "에 의해 _DemandMakeFriendInfoProcess가 호출되었습니다. \n";
-
 	if (auto pRetNode = pClient->pUserNode->GetTemporaryFriendUserData().lock()
 		; pRetNode != nullptr) 
 	{
 		std::wstring stringBuffer = CONVERT_UTIL::StringToWString(pRetNode->GetNickname());
 		int stringSize = stringBuffer.size() * 2; 
 
-		std::cout << "친구추가를 요청한 닉네임은 string : " << pRetNode->GetNickname() << std::endl;
-		std::wcout << "친구추가를 요청한 닉네임은 wstring : " << stringBuffer << std::endl;
-		std::cout << "친구추가를 요청한 닉네임의 사이즈는 : " << stringSize << std::endl;
+		// std::cout << "친구추가를 요청한 닉네임은 string : " << pRetNode->GetNickname() << std::endl;
+		// std::wcout << "친구추가를 요청한 닉네임은 wstring : " << stringBuffer << std::endl;
+		// std::cout << "친구추가를 요청한 닉네임의 사이즈는 : " << stringSize << std::endl;
 
 		memcpy(pClient->buf, reinterpret_cast<const char*>(&NOTIFY_MAKE_FRIEND_INFO), sizeof(int));
 		memcpy(pClient->buf + 4, reinterpret_cast<const char*>(&stringSize), sizeof(int));
@@ -502,39 +457,24 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendInfoProcess(SocketInfo
 
 		pClient->dataSize = 8 + stringSize;
 	}
-
-	std::cout << pClient->pUserNode->GetNickname() << "에 의해 _DemandMakeFriendInfoProcess가 리턴되었습니다. \n";
 }
 
 void SCENE_NETWORK_MANAGER::MainUiScene::_AnswerMakeFriendProcess(SocketInfo* pClient)
 {
-	std::cout << pClient->pUserNode->GetNickname() << "에 의해 _AnswerMakeFriendProcess가 호출되었습니다. \n";
-
 	int iBuffer = reinterpret_cast<int&>(pClient->buf[4]);
 
-	std::cout << "[ANSWER_FRIEND] DEBUG - 1 \n";
-	//shared_ptr<UserData> pBuffer =
-	//	pUserData->SearchUserNodeByNickname(pClient->pUserNode->GetFriendNicknameWithIndex(pClient->pUserNode->GetDemandFriendContIndex()), bBuffer, bIsOnMatch);
 	auto pBuffer = pClient->pUserNode->GetTemporaryFriendUserData().lock();
-
-	std::cout << "[ANSWER_FRIEND] DEBUG - 2 \n";
 
 	// 친구 거절했다 임마. // 내꺼에서만 알면 되지 않나...?
 	if (iBuffer == 0)
 	{
 		if (pBuffer != nullptr)
 		{
-			std::cout << "[ANSWER_FRIEND] DEBUG - 3 \n";
-
 			pClient->pUserNode->SetDeleteFriendID();
 			pBuffer->SetDeleteFriendID();
 		}
 
-		std::cout << "[ANSWER_FRIEND] DEBUG - 4 \n";
-
 		pUDPManager->Push(UDP_PROTOCOL::RESULT_FAIL_FRIEND, pBuffer /*pClient->pUserNode->SetValue().GetSocketInfo()*/);
-
-		std::cout << "[ANSWER_FRIEND] DEBUG - 5 \n";
 
 		// 잘라냅시다. // 내부에서 친구 인자정리함.
 		memcpy(pClient->buf + 4, reinterpret_cast<const char*>(&CONST_FALSE), sizeof(int));
@@ -545,8 +485,6 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_AnswerMakeFriendProcess(SocketInfo* pC
 	{
 		// 친구 거절 정보 알려줄수가 없음 (이미 나갔는 걸? )
 		//InUDPManager.Push(UDP_PROTOCOL::DENY_FRIEND, pBuffer->SetValue().GetSocketInfo());
-
-		std::cout << "[ANSWER_FRIEND] DEBUG - 6 \n";
 
 		// 잘라냅시다. // 내부에서 친구 인자정리함.
 		pClient->pUserNode->SetDeleteFriendID();
@@ -560,43 +498,23 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_AnswerMakeFriendProcess(SocketInfo* pC
 		std::cout << "   [Friend]" << pBuffer->GetKey() << "님이 보낸 친구초대를 " << pClient->pUserNode->GetKey() << "님이 받았어요! \n";
 #endif // _DEBUG_MODE_
 
-		std::cout << "[ANSWER_FRIEND] DEBUG - 7 \n";
-
 		pUDPManager->Push(UDP_PROTOCOL::RESULT_TRUE_FRIEND, pBuffer /*pClient->pUserNode->SetValue().GetSocketInfo()*/);
-
-		std::cout << "[ANSWER_FRIEND] DEBUG - 8 \n";
 
 		pBuffer->AddFriendNickname(pClient->pUserNode->GetNickname());
 
-		std::cout << "[ANSWER_FRIEND] DEBUG - 9 \n";
-
 		pClient->pUserNode->AddFriendNickname(pBuffer->GetNickname());
-
-		std::cout << "[ANSWER_FRIEND] DEBUG - 10 \n";
 
 		pBuffer->SetDeleteFriendID();
 
-		std::cout << "[ANSWER_FRIEND] DEBUG - 11 \n";
-
 		pClient->pUserNode->SetDeleteFriendID();
-
-		std::cout << "[ANSWER_FRIEND] DEBUG - 12 \n";
 
 		memcpy(pClient->buf + 4, reinterpret_cast<const char*>(&CONST_TRUE), sizeof(int));
 	}
 
-	std::cout << "[ANSWER_FRIEND] DEBUG - 13 \n";
-
 	// 앞의 4바이트는 항상 똑같은 값 전달.
 	memcpy(pClient->buf, reinterpret_cast<const char*>(&CHECK_ANSWER_MAKE_FRIEND), sizeof(int));
 
-	std::cout << "[ANSWER_FRIEND] DEBUG - 14 \n";
-
 	pClient->dataSize = 8;
-
-	std::cout << pClient->pUserNode->GetNickname() << "에 의해 _AnswerMakeFriendProcess가 리턴되었습니다. \n";
-
-	std::cout << "[ANSWER_FRIEND] DEBUG - 15 \n";
 }
 
 /*

--- a/Server/Server/SceneNetworkManager/_2_MainUIScene/MainUIScene.cpp
+++ b/Server/Server/SceneNetworkManager/_2_MainUIScene/MainUIScene.cpp
@@ -492,6 +492,10 @@ void SCENE_NETWORK_MANAGER::MainUiScene::_DemandMakeFriendInfoProcess(SocketInfo
 		std::wstring stringBuffer = CONVERT_UTIL::StringToWString(pRetNode->GetNickname());
 		int stringSize = stringBuffer.size() * 2; 
 
+		std::cout << "친구추가를 요청한 닉네임은 string : " << pRetNode->GetNickname() << std::endl;
+		std::wcout << "친구추가를 요청한 닉네임은 wstring : " << stringBuffer << std::endl;
+		std::cout << "친구추가를 요청한 닉네임의 사이즈는 : " << stringSize << std::endl;
+
 		memcpy(pClient->buf, reinterpret_cast<const char*>(&NOTIFY_MAKE_FRIEND_INFO), sizeof(int));
 		memcpy(pClient->buf + 4, reinterpret_cast<const char*>(&stringSize), sizeof(int));
 		memcpy(pClient->buf + 8, stringBuffer.data(), stringSize);

--- a/Server/Server/UserData/UserDataManager.cpp
+++ b/Server/Server/UserData/UserDataManager.cpp
@@ -205,10 +205,10 @@ void UserDataManager::LogoutProcess(shared_ptr<UserData> pUserNode)
 	else
 	{
 		// 친구 기능중 이였으면, 친구 마지막 데이터 삭제함 // 이거 잘못하면 간다 간다 훅간다!
-		if (pUserNode->GetDemandFriendContIndex() != -1)
-		{
+		//if (pUserNode->GetDemandFriendContIndex() != -1)
+		//{
 			pUserNode->SetDeleteFriendID();
-		}
+		//}
 
 		// 파일명 제작
 		string fileNameBuffer = "UserData/Saved/.txt";


### PR DESCRIPTION
서버 내부 친구 로직 수정
 a. 친구 만들 때, 기존 FriendCont를 사용하고, Index를 통해 현재 상태를 파악하는 로직에서, 예비친구를 관리하는 weak_ptr로 변경건
 b. UDP Manger에서 친구 성공, 실패 관리 건
 c. Index를 통해 관리하던 방식에서 바로 Size 확인 후, emplace_back하는 방식으로 변경
 d. 다만 weak_ptr 4를 항상 미리 할당하는 방식 사용으로 인한 메모리 낭비 8 * 4 = 32는 단점사항

commits
[SERVER_DEV95] Fix "Overflow Issue" // DEV_95
[SERVER_DEV95] Fix "Wrong Nickname" // DEV_95
[SERVER_DEV95] Delete Log // DEV_95